### PR TITLE
Declarative Config: Update JSON format and CLI usage description

### DIFF
--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -563,6 +563,10 @@ These properties are:
 | `olm.skipRange`        | `string`                               | `{"type":"olm.skipRange", "value": "<0.9.4"}`                                                                             |
 | `olm.channel`          | `{ name, replaces string }`            | `{"type":"olm.channel", "value":{"name":"singlenamespace-alpha", "replaces":"etcdoperator.v0.9.2"}}`<br>`{"type":"olm.channel", "value":{"name":"clusterwide-alpha"}}`         |
 
+When serving bundles via the registry GRPC server, the `olm.package.provided` and `olm.gvk.provided` properties
+will also be served as `olm.package` and `olm.gvk` respectively, so that existing clients expecting the old names
+will continue to as expected.
+
 #### Representing the upgrade graph in the channel json blob
 
 Currently, a bundle can be added into the index using `opm index add --bundles <list-of-bundle-paths> --mode replaces|semver|semver-skippatch --tag=<index-image-tag>` where the bundle images (like `quay.io/operatorhubio/etcd:v0.9.0`) are included in `<list-of-bundle-path>`. The bundle can also mention bundles it can be upgrade from using the `skips` or `skipRange` fields in the bundle ClusterServiceVersion. With all of these information provided, the upgrade graph of the bundles in the package is calculated and stored in the `channel_entry` table of the sql database that is built inside the index, while the `skips`/`skipRange` information is persisted in the `operatorbundle` table. The `channel_entry` table is always authoritative in terms of calculating the upgrade graph in a package. The operatorbundle table persists the values of `skips`/`skipRange`/`replaces` when the bundle was first unpacked/added to the index, and other index operations could have changed the real graph in `channel_entry`.  

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -597,79 +597,77 @@ $ opm index add --bundles quay.io/operatorhubio/etcd:v0.9.0 --mode replaces --ta
 $ docker push docker.io/my-namespace/community-operators:latest
 $ opm index inspect --image=docker.io/my-namespace/community-operators:latest --output=json
 $ cat community-operators/etcd.json
-[
-    {
-        "schema": "olm.package",
-        "name": "etcd",
-        "defaultChannel": "singlenamespace-alpha",
-        "icon": {
-            "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
-            "mediatype":"image/png"
+{
+    "schema": "olm.package",
+    "name": "etcd",
+    "defaultChannel": "singlenamespace-alpha",
+    "icon": {
+        "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
+        "mediatype":"image/png"
+    },
+    "channels": ["alpha", "singlenamespace-alpha"],
+    "description": "A message about etcd operator, a description of channels"
+}
+{
+    "schema": "olm.bundle", 
+    "name": "etcdoperator-community.v0.6.1",
+    "package": "etcd",
+    "image": "quay.io/operatorhubio/etcd:v0.6.1",
+    "version": "0.6.1",
+    "properties":[
+        {
+            "name":"olm.gvk",
+            "type": "provided",
+            "values":{
+                "group": "etcd.database.coreos.com", 
+                "kind": "EtcdCluster", 
+                "version": "v1beta2"
+            }
         },
-        "channels": ["alpha", "singlenamespace-alpha"],
-        "description": "A message about etcd operator, a description of channels"
-    },
-    {
-        "schema": "olm.bundle", 
-        "name": "etcdoperator-community.v0.6.1",
-        "package": "etcd",
-        "image": "quay.io/operatorhubio/etcd:v0.6.1",
-        "version": "0.6.1",
-        "properties":[
-            {
-                "name":"olm.gvk",
-                "type": "provided",
-                "values":{
-                    "group": "etcd.database.coreos.com", 
-                    "kind": "EtcdCluster", 
-                    "version": "v1beta2"
-                }
-            },
-            {
-                "name": "olm.channel",
-                "values": {
-                    "name": "alpha"
-                }
+        {
+            "name": "olm.channel",
+            "values": {
+                "name": "alpha"
             }
-        ],
-        "relatedImages": [
-            {
-            "name": "etcdv0.6.1",
-            "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
+        }
+    ],
+    "relatedImages": [
+        {
+        "name": "etcdv0.6.1",
+        "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator.v0.9.0",
+    "package": "etcd",
+    "image": "quay.io/operatorhubio/etcd:v0.9.0",
+    "version": "0.9.0",
+    "properties":[
+        {
+            "name":"olm.gvk",
+            "type": "provided",
+            "values":{
+                "group": "etcd.database.coreos.com", 
+                "kind": "EtcdBackup", 
+                "version": "v1beta2"
             }
-        ]
-    },
-    {
-        "schema": "olm.bundle",
-        "name": "etcdoperator.v0.9.0",
-        "package": "etcd",
-        "image": "quay.io/operatorhubio/etcd:v0.9.0",
-        "version": "0.9.0",
-        "properties":[
-            {
-                "name":"olm.gvk",
-                "type": "provided",
-                "values":{
-                    "group": "etcd.database.coreos.com", 
-                    "kind": "EtcdBackup", 
-                    "version": "v1beta2"
-                }
-            },
-            {
-                "name": "olm.channel",
-                "values": {
-                    "name": "singlenamespace-alpha"
-                }
+        },
+        {
+            "name": "olm.channel",
+            "values": {
+                "name": "singlenamespace-alpha"
             }
-        ],
-        "relatedImages" : [
-            {
-                "name": "etcdv0.9.0",
-                "image": "quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8"
-            }
-        ]
-    }
-]
+        }
+    ],
+    "relatedImages" : [
+        {
+            "name": "etcdv0.9.0",
+            "image": "quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8"
+        }
+    ]
+}
 ```
 
 The `opm index add` command will also be enhanced to create `olm.bundle` json blobs for bundles passed onto the command along with a package config file, and append them to the config file.

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -235,7 +235,11 @@ $ cat etcd.json
         },
         {
             "type": "olm.skips",
-            "value" : ["etcdoperator.v0.6.0", "etcdoperator.v0.6.1"]
+            "value" : "etcdoperator.v0.6.0"
+        },
+        {
+            "type": "olm.skips",
+            "value" : "etcdoperator.v0.6.1"
         },
         {
             "type": "olm.channel",
@@ -549,7 +553,7 @@ These properties are:
 | `olm.package.required` | `{ packageName, versionRange string }` | `{"type":"olm.package.required", "value": {"packageName":"test", "versionRange":">=1.2.3 <2.0.0-0"}}`                     |
 | `olm.gvk.provided`     | `{ group, version, kind string }`      | `{"type":"olm.gvk.provided", "value": {"group": "etcd.database.coreos.com", "version": "v1beta2", "kind": "EtcdBackup"}}` |
 | `olm.gvk.required`     | `{ group, version, kind string }`      | `{"type":"olm.gvk.required", "value": {"group": "test.coreos.com", "version": "v1", "kind": "Testapi"}}`                  |
-| `olm.skips`            | `[]string`                             | `{"type":"olm.skips", "value": ["etcdoperator.v0.9.0","etcdoperator.v0.9.2"]}`                                            |
+| `olm.skips`            | `string`                               | `{"type":"olm.skips", "value": "etcdoperator.v0.9.0"}`<br>`{"type":"olm.skips", "value": "etcdoperator.v0.9.2"}`          |
 | `olm.skipRange`        | `string`                               | `{"type":"olm.skipRange", "value": "<0.9.4"}`                                                                             |
 | `olm.channel`          | `{ name, replaces string }`            | `{"type":"olm.channel", "value":{"name":"singlenamespace-alpha", "replaces":"etcdoperator.v0.9.2"}}`<br>`{"type":"olm.channel", "value":{"name":"clusterwide-alpha"}}`         |
 

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -99,14 +99,6 @@ $ cat etcd.json
     "version": "0.6.1",
     "properties":[
         {
-            "name": "olm.package",
-            "type": "provided",
-            "values": {
-                "packageName": "etcd",
-                "version": "0.6.1"
-            }
-        },
-        {
             "name":"olm.gvk",
             "type": "provided",
             "values":{
@@ -136,14 +128,6 @@ $ cat etcd.json
     "image": "quay.io/operatorhubio/etcd:v0.9.0",
     "version": "0.9.0",
     "properties":[
-        {
-            "name": "olm.package",
-            "type": "provided",
-            "values": {
-                "packageName": "etcd",
-                "version": "0.9.0"
-            }
-        },
         {
             "name": "olm.package",
             "type": "required",
@@ -189,14 +173,6 @@ $ cat etcd.json
     "version": "0.9.2",
     "properties":[
         {
-            "name": "olm.package",
-            "type": "provided",
-            "values": {
-                "packageName": "etcd",
-                "version": "0.9.2"
-            }
-        },
-        {
             "name":"olm.gvk",
             "type": "provided",
             "values":{
@@ -227,14 +203,6 @@ $ cat etcd.json
     "image": "quay.io/operatorhubio/etcd:v0.9.2-clusterwide",
     "version": "0.9.2-clusterwide",
     "properties":[
-        {
-            "name": "olm.package",
-            "type": "provided",
-            "values": {
-                "packageName": "etcd",
-                "version": "0.9.2-clusterwide"
-            }
-        },
         {
             "name":"olm.gvk",
             "type": "provided",
@@ -275,14 +243,6 @@ $ cat etcd.json
     "version": "0.9.4",
     "properties":[
         {
-            "name": "olm.package",
-            "type": "provided",
-            "values": {
-                "packageName": "etcd",
-                "version": "0.9.2-clusterwide"
-            }
-        },
-        {
             "name":"olm.gvk",
             "type": "provided",
             "values":{
@@ -322,14 +282,6 @@ $ cat etcd.json
     "image": "quay.io/operatorhubio/etcd:v0.9.4-clusterwide",
     "version": "0.9.4-clusterwide",
     "properties":[
-        {
-            "name": "olm.package",
-            "type": "provided",
-            "values": {
-                "packageName": "etcd",
-                "version": "0.9.4-clusterwide"
-            }
-        },
         {
             "name":"olm.gvk",
             "type": "provided",
@@ -387,14 +339,6 @@ $ cat community-operators/etcd.json
     "version": "0.6.1",
     "properties":[
         {
-            "name": "olm.package",
-            "type": "provided",
-            "values": {
-                "packageName": "etcd",
-                "version": "0.6.1"
-            }
-        },
-        {
             "name":"olm.gvk",
             "type": "provided",
             "values":{
@@ -424,14 +368,6 @@ $ cat community-operators/etcd.json
     "image": "quay.io/operatorhubio/etcd:v0.9.0",
     "version": "0.9.0",
     "properties":[
-        {
-            "name": "olm.package",
-            "type": "provided",
-            "values": {
-                "packageName": "etcd",
-                "version": "0.9.0"
-            }
-        },
         {
             "name":"olm.gvk",
             "type": "provided",
@@ -634,14 +570,6 @@ $ cat community-operators/etcd.json
         "version": "0.6.1",
         "properties":[
             {
-                "name": "olm.package",
-                "type": "provided",
-                "values": {
-                    "packageName": "etcd",
-                    "version": "0.6.1"
-                }
-            },
-            {
                 "name":"olm.gvk",
                 "type": "provided",
                 "values":{
@@ -689,14 +617,6 @@ $ cat community-operators/etcd.json
         "version": "0.6.1",
         "properties":[
             {
-                "name": "olm.package",
-                "type": "provided",
-                "values": {
-                    "packageName": "etcd",
-                    "version": "0.6.1"
-                }
-            },
-            {
                 "name":"olm.gvk",
                 "type": "provided",
                 "values":{
@@ -726,14 +646,6 @@ $ cat community-operators/etcd.json
         "image": "quay.io/operatorhubio/etcd:v0.9.0",
         "version": "0.9.0",
         "properties":[
-            {
-                "name": "olm.package",
-                "type": "provided",
-                "values": {
-                    "packageName": "etcd",
-                    "version": "0.9.0"
-                }
-            },
             {
                 "name":"olm.gvk",
                 "type": "provided",
@@ -783,14 +695,6 @@ $ cat community-operators/etcd.json
     "version": "0.6.1",
     "properties":[
         {
-            "name": "olm.package",
-            "type": "provided",
-            "values": {
-                "packageName": "etcd",
-                "version": "0.6.1"
-            }
-        },
-        {
             "name":"olm.gvk",
             "type": "provided",
             "values":{
@@ -834,14 +738,6 @@ $ cat community-operators/etcd.json
     "version": "0.6.1",
     "properties":[
         {
-            "name": "olm.package",
-            "type": "provided",
-            "values": {
-                "packageName": "etcd",
-                "version": "0.6.1"
-            }
-        },
-        {
             "name":"olm.gvk",
             "type": "provided",
             "values":{
@@ -871,14 +767,6 @@ $ cat community-operators/etcd.json
     "image": "quay.io/operatorhubio/etcd:v0.9.0",
     "version": "0.9.0",
     "properties":[
-        {
-            "name": "olm.package",
-            "type": "provided",
-            "values": {
-                "packageName": "etcd",
-                "version": "0.9.0"
-            }
-        },
         {
             "name":"olm.gvk",
             "type": "provided",

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -90,9 +90,9 @@ $ cat etcd.json
     },
     "channels": ["alpha", "singlenamespace-alpha", "clusterwide-alpha"],
     "description": "A message about etcd operator, a description of channels"
-},
+}
 {
-    "schema": "olm.bundle", 
+    "schema": "olm.bundle",
     "name": "etcdoperator-community.v0.6.1",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
@@ -100,6 +100,7 @@ $ cat etcd.json
     "properties":[
         {
             "name": "olm.package",
+            "type": "provided",
             "values": {
                 "packageName": "etcd",
                 "version": "0.6.1"
@@ -109,14 +110,16 @@ $ cat etcd.json
             "name":"olm.gvk",
             "type": "provided",
             "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdCluster", 
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
                 "version": "v1beta2"
             }
         },
         {
             "name": "olm.channel",
-            "value": "alpha"
+            "values": {
+                "name": "alpha"
+            }
         }
     ],
     "relatedImages": [
@@ -125,7 +128,7 @@ $ cat etcd.json
             "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
         }
     ]
-},
+}
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.0",
@@ -135,27 +138,40 @@ $ cat etcd.json
     "properties":[
         {
             "name": "olm.package",
+            "type": "provided",
             "values": {
                 "packageName": "etcd",
                 "version": "0.9.0"
             }
         },
         {
+            "name": "olm.package",
+            "type": "required",
+            "values": {
+                "packageName": "other-operator",
+                "version": ">=1.2.0 <2.0.0-0"
+            }
+        },
+        {
             "name":"olm.gvk",
             "type": "provided",
             "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdBackup", 
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
         {
             "name": "olm.channel",
-            "value": "singlenamespace-alpha"
-        }
+            "values": {
+                "name": "singlenamespace-alpha"
+            }
+        },
         {
             "name": "olm.channel",
-            "value": "clusterwide-alpha"
+            "values": {
+                "name": "clusterwide-alpha"
+            }
         }
     ],
     "relatedImages" : [
@@ -164,7 +180,7 @@ $ cat etcd.json
             "image": "quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8"
         }
     ]
-},
+}
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.2",
@@ -174,6 +190,7 @@ $ cat etcd.json
     "properties":[
         {
             "name": "olm.package",
+            "type": "provided",
             "values": {
                 "packageName": "etcd",
                 "version": "0.9.2"
@@ -183,15 +200,17 @@ $ cat etcd.json
             "name":"olm.gvk",
             "type": "provided",
             "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdRestore", 
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdRestore",
                 "version": "v1beta2"
             }
         },
         {
             "name": "olm.channel",
-            "value": "singlenamespace-alpha",
-            "replaces": "etcdoperator.v0.9.0"
+            "values": {
+                "name": "singlenamespace-alpha",
+                "replaces": "etcdoperator.v0.9.0"
+            }
         }
     ],
     "relatedImages":[
@@ -200,16 +219,17 @@ $ cat etcd.json
             "image": "quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2"
         }
     ]
-},
+}
 {
     "schema": "olm.bundle",
-    "name": "etcdoperator.v0.9.2-clusterwide", 
+    "name": "etcdoperator.v0.9.2-clusterwide",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.2-clusterwide",
     "version": "0.9.2-clusterwide",
     "properties":[
         {
             "name": "olm.package",
+            "type": "provided",
             "values": {
                 "packageName": "etcd",
                 "version": "0.9.2-clusterwide"
@@ -219,14 +239,14 @@ $ cat etcd.json
             "name":"olm.gvk",
             "type": "provided",
             "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdBackup", 
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
         {
             "name": "skipRange",
-            "value": ">=0.9.0 <0.9.2"
+            "value": ">=0.9.0 <0.9.2-0"
         },
         {
             "name": "skips",
@@ -234,9 +254,11 @@ $ cat etcd.json
         },
         {
             "name": "olm.channel",
-            "value": "clusterwide-alpha",
-            "replaces": "etcdoperator.v0.9.0"
-        }  
+            "values": {
+                "name":"clusterwide-alpha",
+                "replaces": "etcdoperator.v0.9.0"
+            }
+        }
     ],
     "relatedImages":[
         {
@@ -244,7 +266,7 @@ $ cat etcd.json
             "image":"quay.io/coreos/etcd-operator@sha256:c0301e4686c3ed4206e370b42de5a3bd2229b9fb4906cf85f3f30650424abec2"
         }
     ]
-},
+}
 {
     "schema": "olm.bundle",
     "name" : "etcdoperator.v0.9.4",
@@ -254,6 +276,7 @@ $ cat etcd.json
     "properties":[
         {
             "name": "olm.package",
+            "type": "provided",
             "values": {
                 "packageName": "etcd",
                 "version": "0.9.2-clusterwide"
@@ -263,8 +286,8 @@ $ cat etcd.json
             "name":"olm.gvk",
             "type": "provided",
             "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdBackup", 
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
@@ -272,15 +295,17 @@ $ cat etcd.json
             "name":"olm.gvk",
             "type": "required",
             "values":{
-                "group": "testapi.coreos.com", 
-                "kind": "testapi", 
+                "group": "testapi.coreos.com",
+                "kind": "Testapi",
                 "version": "v1"
             }
         },
         {
             "name": "olm.channel",
-            "value": "singlenamespace-alpha",
-            "replaces": "etcdopertor.v0.9.2"
+            "values": {
+                "name": "singlenamespace-alpha",
+                "replaces": "etcdoperator.v0.9.2"
+            }
         }
     ],
     "relatedImages":[
@@ -289,7 +314,7 @@ $ cat etcd.json
             "image": "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b"
         }
     ]
-},
+}
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.4-clusterwide",
@@ -299,6 +324,7 @@ $ cat etcd.json
     "properties":[
         {
             "name": "olm.package",
+            "type": "provided",
             "values": {
                 "packageName": "etcd",
                 "version": "0.9.4-clusterwide"
@@ -308,15 +334,17 @@ $ cat etcd.json
             "name":"olm.gvk",
             "type": "provided",
             "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdBackup", 
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
         {
             "name": "olm.channel",
-            "value": "clusterwide-alpha",
-            "replaces": "etcdoperator.v0.9.2-clusterwide"
+            "values": {
+                "name": "clusterwide-alpha",
+                "replaces": "etcdoperator.v0.9.2-clusterwide"
+            }
         }
     ],
     "relatedImages":[
@@ -350,7 +378,7 @@ $ cat community-operators/etcd.json
     },
     "channels": ["alpha", "singlenamespace-alpha", "clusterwide-alpha"],
     "description": "A message about etcd operator, a description of channels"
-},
+}
 {
     "schema": "olm.bundle", 
     "name": "etcdoperator-community.v0.6.1",
@@ -360,6 +388,7 @@ $ cat community-operators/etcd.json
     "properties":[
         {
             "name": "olm.package",
+            "type": "provided",
             "values": {
                 "packageName": "etcd",
                 "version": "0.6.1"
@@ -375,8 +404,10 @@ $ cat community-operators/etcd.json
             }
         },
         {
-        "name": "olm.channel",
-        "value": "alpha"
+            "name": "olm.channel",
+            "values": {
+                "name": "alpha"
+            }
         }
     ],
     "relatedImages": [
@@ -385,7 +416,7 @@ $ cat community-operators/etcd.json
             "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
         }
     ]
-},
+}
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.0",
@@ -395,6 +426,7 @@ $ cat community-operators/etcd.json
     "properties":[
         {
             "name": "olm.package",
+            "type": "provided",
             "values": {
                 "packageName": "etcd",
                 "version": "0.9.0"
@@ -411,16 +443,22 @@ $ cat community-operators/etcd.json
         },
         {
             "name": "olm.channel",
-            "value": "alpha",
-            "replaces":"etcdoperator-community.v0.6.1"
+            "values": {
+                "name": "alpha",
+                "replaces":"etcdoperator-community.v0.6.1"
+            }
         },
         {
             "name": "olm.channel",
-            "value": "singlenamespace-alpha"
+            "values": {
+                "name": "singlenamespace-alpha"
+            }
         },
         {
             "name": "olm.channel",
-            "value": "clusterwide-alpha"
+            "values": {
+                "name": "clusterwide-alpha"
+            }
         }
     ],
     "relatedImages" : [
@@ -429,7 +467,7 @@ $ cat community-operators/etcd.json
             "image": "quay.io/coreos/etcd-operator@sha256:db563baa8194fcfe39d1df744ed70024b0f1f9e9b55b5923c2f3a413c44dc6b8"
         }
     ]
-},
+}
 .
 .
 .
@@ -563,7 +601,7 @@ etcdoperator.v0.9.4-clusterwide  quay.io/operatorhubio/etcd:v0.9.4-clusterwide  
 etcdoperator.v0.9.4              quay.io/operatorhubio/etcd:v0.9.4              0.9.4                                etcdoperator.v0.9.2   
 ```
 
-This information will be captured in the `properties.<"olm.channel">.replaces`, `properties.skips` and `properties.skipRange` of the `olm.bundle` blob. In the `properties.<"olm.channel">` object for each channel, the bundle that replaces a previous bundle is captured in the `replaces` field. An upgrade edge in a channel is represented by: bundle.properties<"olm.channel">.replaces <- bundle name. 
+This information will be captured in the `properties.<"olm.channel">.values.replaces`, `properties.skips` and `properties.skipRange` of the `olm.bundle` blob. In the `properties.<"olm.channel">` object for each channel, the bundle that replaces a previous bundle is captured in the `values.replaces` field. An upgrade edge in a channel is represented by: `bundle.properties.<"olm.channel">.values.replaces` <- `bundle.name`.
 
 #### Creating the json/yaml config file to represent a package
 
@@ -597,6 +635,7 @@ $ cat community-operators/etcd.json
         "properties":[
             {
                 "name": "olm.package",
+                "type": "provided",
                 "values": {
                     "packageName": "etcd",
                     "version": "0.6.1"
@@ -613,7 +652,9 @@ $ cat community-operators/etcd.json
             }, 
             {
                 "name": "olm.channel",
-                "value": "alpha",
+                "values": {
+                    "name": "alpha"
+                }
             }
         ],
         "relatedImages": [
@@ -649,6 +690,7 @@ $ cat community-operators/etcd.json
         "properties":[
             {
                 "name": "olm.package",
+                "type": "provided",
                 "values": {
                     "packageName": "etcd",
                     "version": "0.6.1"
@@ -665,7 +707,9 @@ $ cat community-operators/etcd.json
             },
             {
                 "name": "olm.channel",
-                "value": "alpha",
+                "values": {
+                    "name": "alpha"
+                }
             }
         ],
         "relatedImages": [
@@ -684,6 +728,7 @@ $ cat community-operators/etcd.json
         "properties":[
             {
                 "name": "olm.package",
+                "type": "provided",
                 "values": {
                     "packageName": "etcd",
                     "version": "0.9.0"
@@ -698,9 +743,11 @@ $ cat community-operators/etcd.json
                     "version": "v1beta2"
                 }
             },
-             {
+            {
                 "name": "olm.channel",
-                "value": "singlenamespace-alpha",
+                "values": {
+                    "name": "singlenamespace-alpha"
+                }
             }
         ],
         "relatedImages" : [
@@ -727,7 +774,7 @@ $ cat community-operators/etcd.json
     },
     "channels": ["alpha"],
     "description": "A message about etcd operator, a description of channels"
-},
+}
 {
     "schema": "olm.bundle", 
     "name": "etcdoperator-community.v0.6.1",
@@ -737,6 +784,7 @@ $ cat community-operators/etcd.json
     "properties":[
         {
             "name": "olm.package",
+            "type": "provided",
             "values": {
                 "packageName": "etcd",
                 "version": "0.6.1"
@@ -753,7 +801,9 @@ $ cat community-operators/etcd.json
         },
         {
             "name":"olm.channel",
-            "value": "alpha"
+            "values": {
+                "name": "alpha"
+            }
         }
     ],
     "relatedImages": [
@@ -775,7 +825,7 @@ $ cat community-operators/etcd.json
     },
     "channels": ["alpha", "singlenamespace-alpha"],
     "description": "A message about etcd operator, a description of channels"
-},
+}
 {
     "schema": "olm.bundle", 
     "name": "etcdoperator-community.v0.6.1",
@@ -785,6 +835,7 @@ $ cat community-operators/etcd.json
     "properties":[
         {
             "name": "olm.package",
+            "type": "provided",
             "values": {
                 "packageName": "etcd",
                 "version": "0.6.1"
@@ -801,7 +852,9 @@ $ cat community-operators/etcd.json
         },
         {
             "name":"olm.channel",
-            "value": "alpha"
+            "values": {
+                "name": "alpha"
+            }
         }
     ],
     "relatedImages": [
@@ -810,7 +863,7 @@ $ cat community-operators/etcd.json
         "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
         }
     ]
-},
+}
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.0",
@@ -820,6 +873,7 @@ $ cat community-operators/etcd.json
     "properties":[
         {
             "name": "olm.package",
+            "type": "provided",
             "values": {
                 "packageName": "etcd",
                 "version": "0.9.0"
@@ -836,7 +890,9 @@ $ cat community-operators/etcd.json
         },
         {
             "name":"olm.channel",
-            "value": "singlenamespace-alpha"
+            "values": {
+                "name": "singlenamespace-alpha"
+            }
         }
     ],
     "relatedImages" : [

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -96,13 +96,27 @@ $ cat etcd.json
     "name": "etcdoperator-community.v0.6.1",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
+            }
+        },
+        {
+            "type":"olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
             }
         },
         {
@@ -132,13 +146,27 @@ $ cat etcd.json
     "name": "etcdoperator.v0.9.0",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.0",
-    "version": "0.9.0",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.0"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.0"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
+                "version": "v1beta2"
             }
         },
         {
@@ -174,13 +202,27 @@ $ cat etcd.json
     "name": "etcdoperator.v0.9.2",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.2",
-    "version": "0.9.2",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.2"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.2"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdRestore",
+                "version": "v1beta2"
             }
         },
         {
@@ -211,13 +253,27 @@ $ cat etcd.json
     "name": "etcdoperator.v0.9.2-clusterwide",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.2-clusterwide",
-    "version": "0.9.2-clusterwide",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.2-clusterwide"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.2-clusterwide"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
+                "version": "v1beta2"
             }
         },
         {
@@ -260,8 +316,14 @@ $ cat etcd.json
     "name" : "etcdoperator.v0.9.4",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.4",
-    "version": "0.9.4",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.4"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
@@ -274,6 +336,14 @@ $ cat etcd.json
             "value": {
                 "packageName": "test",
                 "versionRange": ">=1.2.3 <2.0.0-0"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
+                "version": "v1beta2"
             }
         },
         {
@@ -312,13 +382,27 @@ $ cat etcd.json
     "name": "etcdoperator.v0.9.4-clusterwide",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.4-clusterwide",
-    "version": "0.9.4-clusterwide",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.4-clusterwide"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.4-clusterwide"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
+                "version": "v1beta2"
             }
         },
         {
@@ -373,13 +457,27 @@ $ cat community-operators/etcd.json
     "name": "etcdoperator-community.v0.6.1",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
             }
         },
         {
@@ -409,13 +507,27 @@ $ cat community-operators/etcd.json
     "name": "etcdoperator.v0.9.0",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.0",
-    "version": "0.9.0",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.0"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.0"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
+                "version": "v1beta2"
             }
         },
         {
@@ -529,7 +641,6 @@ This information is currently captured in the `package` table.
     "name": "<operatorbundle_name>",
     "package": "<package_name>",
     "image": "<operatorbundle_path>",
-    "version": "<version>",
     "properties":["<list of properties of bundle that encode bundle dependencies(provided and required apis) upgrade graph info(skips/skipRange), and bundle channel/s info>"],
     "relatedImages" : ["<list-of-related-images>"]
 }
@@ -563,8 +674,10 @@ These properties are:
 
 | Type                   | Value Schema                           | Example                                                                                                                   |
 |------------------------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `olm.package`          | `{ packageName, version string }`      | `{"type":"olm.package", "value": {"packageName":"etcd", "version":"0.9.4"}}`                                              |
 | `olm.package.provided` | `{ packageName, version string }`      | `{"type":"olm.package.provided", "value": {"packageName":"etcd", "version":"0.9.4"}}`                                     |
 | `olm.package.required` | `{ packageName, versionRange string }` | `{"type":"olm.package.required", "value": {"packageName":"test", "versionRange":">=1.2.3 <2.0.0-0"}}`                     |
+| `olm.gvk`              | `{ group, version, kind string }`      | `{"type":"olm.gvk", "value": {"group": "etcd.database.coreos.com", "version": "v1beta2", "kind": "EtcdBackup"}}`          |
 | `olm.gvk.provided`     | `{ group, version, kind string }`      | `{"type":"olm.gvk.provided", "value": {"group": "etcd.database.coreos.com", "version": "v1beta2", "kind": "EtcdBackup"}}` |
 | `olm.gvk.required`     | `{ group, version, kind string }`      | `{"type":"olm.gvk.required", "value": {"group": "test.coreos.com", "version": "v1", "kind": "Testapi"}}`                  |
 | `olm.skips`            | `string`                               | `{"type":"olm.skips", "value": "etcdoperator.v0.9.0"}`<br>`{"type":"olm.skips", "value": "etcdoperator.v0.9.2"}`          |
@@ -572,6 +685,7 @@ These properties are:
 | `olm.channel`          | `{ name, replaces string }`            | `{"type":"olm.channel", "value":{"name":"singlenamespace-alpha", "replaces":"etcdoperator.v0.9.2"}}`<br>`{"type":"olm.channel", "value":{"name":"clusterwide-alpha"}}`         |
 
 To support both old and new clients, `opm` will ensure that there are matching `olm.gvk`/`olm.gvk.provided` and `olm.package`/`olm.package.provided` properties present in bundle properties when migrating from the sqlite database representation and also during build time and validation. When all supported clients have been transitioned to understand the new property names, `olm.gvk` and `olm.package` will be retired.
+Since the `olm.bundle` schema also has a top-level field for `package`, `opm` will verify that it aligns with the `olm.package`/`olm.package.provided` properties.
 
 #### Filesystem structure
 
@@ -696,13 +810,27 @@ $ cat community-operators/etcd.json
     "name": "etcdoperator-community.v0.6.1",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
             }
         },
         {
@@ -746,13 +874,27 @@ $ cat community-operators/etcd.json
     "name": "etcdoperator-community.v0.6.1",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
             }
         },
         {
@@ -782,13 +924,27 @@ $ cat community-operators/etcd.json
     "name": "etcdoperator.v0.9.0",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.0",
-    "version": "0.9.0",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.0"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.0"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
+                "version": "v1beta2"
             }
         },
         {
@@ -834,13 +990,27 @@ $ cat community-operators/etcd.json
     "name": "etcdoperator-community.v0.6.1",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
             }
         },
         {
@@ -882,13 +1052,27 @@ $ cat community-operators/etcd.json
     "name": "etcdoperator-community.v0.6.1",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
             }
         },
         {
@@ -918,13 +1102,27 @@ $ cat community-operators/etcd.json
     "name": "etcdoperator.v0.9.0",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.0",
-    "version": "0.9.0",
     "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.0"
+            }
+        },
         {
             "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.0"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
+                "version": "v1beta2"
             }
         },
         {

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -99,17 +99,24 @@ $ cat etcd.json
     "version": "0.6.1",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
+        {
+            "type":"olm.gvk",
+            "value": {
+                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdCluster",
                 "version": "v1beta2"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "alpha"
             }
         }
@@ -129,31 +136,30 @@ $ cat etcd.json
     "version": "0.9.0",
     "properties":[
         {
-            "name": "olm.package",
-            "type": "required",
-            "values": {
-                "packageName": "other-operator",
-                "version": ">=1.2.0 <2.0.0-0"
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.0"
             }
         },
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "singlenamespace-alpha"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "clusterwide-alpha"
             }
         }
@@ -173,17 +179,24 @@ $ cat etcd.json
     "version": "0.9.2",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.2"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdRestore",
                 "version": "v1beta2"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "singlenamespace-alpha",
                 "replaces": "etcdoperator.v0.9.0"
             }
@@ -204,26 +217,33 @@ $ cat etcd.json
     "version": "0.9.2-clusterwide",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.2-clusterwide"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
         {
-            "name": "skipRange",
-            "value": ">=0.9.0 <0.9.2-0"
+            "type": "olm.skipRange",
+            "value": ">=0.9.0 <=0.9.2-0"
         },
         {
-            "name": "skips",
+            "type": "olm.skips",
             "value" : "v0.12.2, v0.14.1"
         },
         {
-            "name": "olm.channel",
-            "values": {
-                "name":"clusterwide-alpha",
+            "type": "olm.channel",
+            "value": {
+                "name": "clusterwide-alpha",
                 "replaces": "etcdoperator.v0.9.0"
             }
         }
@@ -243,26 +263,40 @@ $ cat etcd.json
     "version": "0.9.4",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.2-clusterwide"
+            }
+        },
+        {
+            "type": "olm.requiredPackage",
+            "value": {
+                "packageName": "test",
+                "versionRange": ">=1.2.3 <2.0.0-0"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
         {
-            "name":"olm.gvk",
-            "type": "required",
-            "values":{
+            "type": "olm.gvk",
+            "value": {
+                "type": "required",
                 "group": "testapi.coreos.com",
                 "kind": "Testapi",
                 "version": "v1"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "singlenamespace-alpha",
                 "replaces": "etcdoperator.v0.9.2"
             }
@@ -283,17 +317,24 @@ $ cat etcd.json
     "version": "0.9.4-clusterwide",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.4-clusterwide"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "clusterwide-alpha",
                 "replaces": "etcdoperator.v0.9.2-clusterwide"
             }
@@ -332,24 +373,31 @@ $ cat community-operators/etcd.json
     "description": "A message about etcd operator, a description of channels"
 }
 {
-    "schema": "olm.bundle", 
+    "schema": "olm.bundle",
     "name": "etcdoperator-community.v0.6.1",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
     "version": "0.6.1",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdCluster", 
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
                 "version": "v1beta2"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "alpha"
             }
         }
@@ -369,30 +417,37 @@ $ cat community-operators/etcd.json
     "version": "0.9.0",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdBackup", 
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.0"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "alpha",
                 "replaces":"etcdoperator-community.v0.6.1"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "singlenamespace-alpha"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "clusterwide-alpha"
             }
         }
@@ -537,7 +592,12 @@ etcdoperator.v0.9.4-clusterwide  quay.io/operatorhubio/etcd:v0.9.4-clusterwide  
 etcdoperator.v0.9.4              quay.io/operatorhubio/etcd:v0.9.4              0.9.4                                etcdoperator.v0.9.2   
 ```
 
-This information will be captured in the `properties.<"olm.channel">.values.replaces`, `properties.skips` and `properties.skipRange` of the `olm.bundle` blob. In the `properties.<"olm.channel">` object for each channel, the bundle that replaces a previous bundle is captured in the `values.replaces` field. An upgrade edge in a channel is represented by: `bundle.properties.<"olm.channel">.values.replaces` <- `bundle.name`.
+This information will be captured in the `properties.<"olm.channel">.value.replaces`, `properties.<"olm.skips">.value` and `properties.<"olm.skipRange">.value` of the `olm.bundle` blob.
+
+When building an internal model of the upgrade graph for a particular channel, the `properties.<"olm.channel">.value.replaces` and `properties.<"olm.skips">.value` fields are used to count the number of incoming edges that each bundle has.
+To be valid, a channel's bundles must form a directed acyclic graph, and there must be exactly one bundle with zero incoming edges.
+
+The `properties.<"olm.skipRange">` property is currently consumed only by the OLM resolver to allow bundles to "override" the graph and form new implicit upgrade edges to allow direct upgrades from other bundles whose versions fall within the `skipRange`.
 
 #### Creating the json/yaml config file to represent a package
 
@@ -550,49 +610,54 @@ $ tree community-operators
 ├── etcd.json
 
 $ cat community-operators/etcd.json
-[
-    {
-        "schema": "olm.package",
-        "name": "etcd",
-        "defaultChannel": "singlenamespace-alpha",
-        "icon": {
-            "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
-            "mediatype":"image/png"
-        },
-        "channels": ["alpha"],
-        "description": "A message about etcd operator, a description of channels"
+{
+    "schema": "olm.package",
+    "name": "etcd",
+    "defaultChannel": "singlenamespace-alpha",
+    "icon": {
+        "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
+        "mediatype":"image/png"
     },
-    {
-        "schema": "olm.bundle", 
-        "name": "etcdoperator-community.v0.6.1",
-        "package": "etcd",
-        "image": "quay.io/operatorhubio/etcd:v0.6.1",
-        "version": "0.6.1",
-        "properties":[
-            {
-                "name":"olm.gvk",
-                "type": "provided",
-                "values":{
-                    "group": "etcd.database.coreos.com", 
-                    "kind": "EtcdCluster", 
-                    "version": "v1beta2"
-                }
-            }, 
-            {
-                "name": "olm.channel",
-                "values": {
-                    "name": "alpha"
-                }
+    "channels": ["alpha"],
+    "description": "A message about etcd operator, a description of channels"
+}
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.6.1",
+    "package": "etcd",
+    "image": "quay.io/operatorhubio/etcd:v0.6.1",
+    "version": "0.6.1",
+    "properties":[
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
             }
-        ],
-        "relatedImages": [
-            {
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.channel",
+            "value": {
+                "name": "alpha"
+            }
+        }
+    ],
+    "relatedImages": [
+        {
             "name": "etcdv0.6.1",
             "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
-            }
-        ]
-    }
-]
+        }
+    ]
+}
 $ opm index add --bundles quay.io/operatorhubio/etcd:v0.9.0 --mode replaces --tag docker.io/my-namespace/community-operators:latest
 $ docker push docker.io/my-namespace/community-operators:latest
 $ opm index inspect --image=docker.io/my-namespace/community-operators:latest --output=json
@@ -609,32 +674,39 @@ $ cat community-operators/etcd.json
     "description": "A message about etcd operator, a description of channels"
 }
 {
-    "schema": "olm.bundle", 
+    "schema": "olm.bundle",
     "name": "etcdoperator-community.v0.6.1",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
     "version": "0.6.1",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdCluster", 
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
                 "version": "v1beta2"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "alpha"
             }
         }
     ],
     "relatedImages": [
         {
-        "name": "etcdv0.6.1",
-        "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
+            "name": "etcdv0.6.1",
+            "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
         }
     ]
 }
@@ -646,17 +718,24 @@ $ cat community-operators/etcd.json
     "version": "0.9.0",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdBackup", 
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.0"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
         {
-            "name": "olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "singlenamespace-alpha"
             }
         }
@@ -686,32 +765,39 @@ $ cat community-operators/etcd.json
     "description": "A message about etcd operator, a description of channels"
 }
 {
-    "schema": "olm.bundle", 
+    "schema": "olm.bundle",
     "name": "etcdoperator-community.v0.6.1",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
     "version": "0.6.1",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdCluster", 
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
                 "version": "v1beta2"
             }
         },
         {
-            "name":"olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "alpha"
             }
         }
     ],
     "relatedImages": [
         {
-        "name": "etcdv0.6.1",
-        "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
+            "name": "etcdv0.6.1",
+            "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
         }
     ]
 }
@@ -729,32 +815,39 @@ $ cat community-operators/etcd.json
     "description": "A message about etcd operator, a description of channels"
 }
 {
-    "schema": "olm.bundle", 
+    "schema": "olm.bundle",
     "name": "etcdoperator-community.v0.6.1",
     "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
     "version": "0.6.1",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdCluster", 
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
                 "version": "v1beta2"
             }
         },
         {
-            "name":"olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "alpha"
             }
         }
     ],
     "relatedImages": [
         {
-        "name": "etcdv0.6.1",
-        "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
+            "name": "etcdv0.6.1",
+            "image": "quay.io/coreos/etcd-operator@sha256:bd944a211eaf8f31da5e6d69e8541e7cada8f16a9f7a5a570b22478997819943"
         }
     ]
 }
@@ -766,17 +859,24 @@ $ cat community-operators/etcd.json
     "version": "0.9.0",
     "properties":[
         {
-            "name":"olm.gvk",
-            "type": "provided",
-            "values":{
-                "group": "etcd.database.coreos.com", 
-                "kind": "EtcdBackup", 
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.0"
+            }
+        },
+        {
+            "type": "olm.gvk",
+            "value": {
+                "type": "provided",
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
         {
-            "name":"olm.channel",
-            "values": {
+            "type": "olm.channel",
+            "value": {
                 "name": "singlenamespace-alpha"
             }
         }

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -59,7 +59,8 @@ A human consumable representation of packages in an index in the form of json/ya
 ## Non-goals 
 
 1. Enumerate/implement tooling to allow different operations to be performed on the package representations. Numerous tooling(eg those that allow operation on files) that already exists can be leveraged to perform various operations on package representations. 
-2. Advanced tooling to verify dependency satisfiability for individual bundles, channel upgrade graph validity for each channel in a package etc. This will be considered in a separate enhancement.      
+2. Advanced tooling to verify dependency satisfiability for individual bundles, channel upgrade graph validity for each channel in a package etc. This will be considered in a separate enhancement.
+3. Define an exhaustive or authoritative set of bundle properties. This proposal will document only the properties necessary to maintain backwards-compatibility with the existing GRPC API.
 
 ## User Stories 
 
@@ -99,16 +100,15 @@ $ cat etcd.json
     "version": "0.6.1",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
             }
         },
         {
-            "type":"olm.gvk",
+            "type":"olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdCluster",
                 "version": "v1beta2"
@@ -136,16 +136,15 @@ $ cat etcd.json
     "version": "0.9.0",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.0"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdBackup",
                 "version": "v1beta2"
@@ -179,16 +178,15 @@ $ cat etcd.json
     "version": "0.9.2",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.2"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdRestore",
                 "version": "v1beta2"
@@ -217,16 +215,15 @@ $ cat etcd.json
     "version": "0.9.2-clusterwide",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.2-clusterwide"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdBackup",
                 "version": "v1beta2"
@@ -238,7 +235,7 @@ $ cat etcd.json
         },
         {
             "type": "olm.skips",
-            "value" : "v0.12.2, v0.14.1"
+            "value" : ["etcdoperator.v0.6.0", "etcdoperator.v0.6.1"]
         },
         {
             "type": "olm.channel",
@@ -263,32 +260,30 @@ $ cat etcd.json
     "version": "0.9.4",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.2-clusterwide"
             }
         },
         {
-            "type": "olm.requiredPackage",
+            "type": "olm.package.required",
             "value": {
                 "packageName": "test",
                 "versionRange": ">=1.2.3 <2.0.0-0"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdBackup",
                 "version": "v1beta2"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.required",
             "value": {
-                "type": "required",
                 "group": "testapi.coreos.com",
                 "kind": "Testapi",
                 "version": "v1"
@@ -317,16 +312,15 @@ $ cat etcd.json
     "version": "0.9.4-clusterwide",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.4-clusterwide"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdBackup",
                 "version": "v1beta2"
@@ -380,16 +374,15 @@ $ cat community-operators/etcd.json
     "version": "0.6.1",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdCluster",
                 "version": "v1beta2"
@@ -417,16 +410,15 @@ $ cat community-operators/etcd.json
     "version": "0.9.0",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.0"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdBackup",
                 "version": "v1beta2"
@@ -516,7 +508,7 @@ Since each bundle in the index belongs to a channel in a package, the index itse
 
 The config file for each package will have a stream of json objects, representing the package and bundle information for that package. Currently, this information is stored in a sql database inside the index. To capture all the information previously stored in this database but in a normalized way, the config file will have two kinds of json blob: 
 
-1. The json blob capturing package information. 
+##### Declarative Package Format
 ```json
 {
     "schema": "olm.package",
@@ -529,7 +521,7 @@ The config file for each package will have a stream of json objects, representin
 ```
 This information is currently captured in the `package` table.
 
-2. The json blob capturing the bundle information.
+##### Declarative Bundle Format
 ```json
 {
     "schema": "olm.bundle",
@@ -540,10 +532,26 @@ This information is currently captured in the `package` table.
     "properties":["<list of properties of bundle that encode bundle dependencies(provided and required apis) upgrade graph info(skips/skipRange), and bundle channel/s info>"],
     "relatedImages" : ["<list-of-related-images>"]
 }
-
 ```
 
 This information is currently captured in the `operatorbundle`, `properties`, `channel`, `channel_entry`, `api`, `api_provider`, `api_requirer` and `related_image` tables in the sql database.  
+
+###### A note on properties
+
+Defining bundle properties is not within the scope of this proposal. For the purposes of the declarative configuration format, properties are opaque JSON blobs that can convey arbitrary metadata about a particular bundle.
+
+However, for backwards compatibility reasons, a subset of well-defined properties will be understood by `opm` so that declarative config representations can be transparently swapped in for the deprecated database backend while still serving the same GRPC API.
+These properties are:
+
+| Type                   | Value Schema                           | Example                                                                                                                   |
+|------------------------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `olm.package.provided` | `{ packageName, version string }`      | `{"type":"olm.package.provided", "value": {"packageName":"etcd", "version":"0.9.4"}}`                                     |
+| `olm.package.required` | `{ packageName, versionRange string }` | `{"type":"olm.package.required", "value": {"packageName":"test", "versionRange":">=1.2.3 <2.0.0-0"}}`                     |
+| `olm.gvk.provided`     | `{ group, version, kind string }`      | `{"type":"olm.gvk.provided", "value": {"group": "etcd.database.coreos.com", "version": "v1beta2", "kind": "EtcdBackup"}}` |
+| `olm.gvk.required`     | `{ group, version, kind string }`      | `{"type":"olm.gvk.required", "value": {"group": "test.coreos.com", "version": "v1", "kind": "Testapi"}}`                  |
+| `olm.skips`            | `[]string`                             | `{"type":"olm.skips", "value": ["etcdoperator.v0.9.0","etcdoperator.v0.9.2"]}`                                            |
+| `olm.skipRange`        | `string`                               | `{"type":"olm.skipRange", "value": "<0.9.4"}`                                                                             |
+| `olm.channel`          | `{ name, replaces string }`            | `{"type":"olm.channel", "value":{"name":"singlenamespace-alpha", "replaces":"etcdoperator.v0.9.2"}}`<br>`{"type":"olm.channel", "value":{"name":"clusterwide-alpha"}}`         |
 
 #### Representing the upgrade graph in the channel json blob
 
@@ -629,16 +637,15 @@ $ cat community-operators/etcd.json
     "version": "0.6.1",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdCluster",
                 "version": "v1beta2"
@@ -681,16 +688,15 @@ $ cat community-operators/etcd.json
     "version": "0.6.1",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdCluster",
                 "version": "v1beta2"
@@ -718,16 +724,15 @@ $ cat community-operators/etcd.json
     "version": "0.9.0",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.0"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdBackup",
                 "version": "v1beta2"
@@ -772,16 +777,15 @@ $ cat community-operators/etcd.json
     "version": "0.6.1",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdCluster",
                 "version": "v1beta2"
@@ -822,16 +826,15 @@ $ cat community-operators/etcd.json
     "version": "0.6.1",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.6.1"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdCluster",
                 "version": "v1beta2"
@@ -859,16 +862,15 @@ $ cat community-operators/etcd.json
     "version": "0.9.0",
     "properties":[
         {
-            "type": "olm.package",
+            "type": "olm.package.provided",
             "value": {
                 "packageName": "etcd",
                 "version": "0.9.0"
             }
         },
         {
-            "type": "olm.gvk",
+            "type": "olm.gvk.provided",
             "value": {
-                "type": "provided",
                 "group": "etcd.database.coreos.com",
                 "kind": "EtcdBackup",
                 "version": "v1beta2"
@@ -958,7 +960,6 @@ rpc ListBundles(ListBundlesRequest) returns (stream Bundle) {}
 ```
 
 Once the declarative package configs are available inside an index, these configs will be used to serve the content for these api endpoints instead of the sqllite database. A new flag `configs` will be introduced under `opm registry serve` that will accept a directory of config files as input, and use that directory to serve the grpc endpoints (instead of `registry serve --database index.db`).
-
 
 ## Migration Plan
 

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -94,9 +94,7 @@ $ cat etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator-community.v0.6.1",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -130,9 +128,7 @@ $ cat etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.0",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.0",
-    "version": "0.9.0",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -172,9 +168,7 @@ $ cat etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.2",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.2",
-    "version": "0.9.2",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -209,9 +203,7 @@ $ cat etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.2-clusterwide",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.2-clusterwide",
-    "version": "0.9.2-clusterwide",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -258,9 +250,7 @@ $ cat etcd.json
 {
     "schema": "olm.bundle",
     "name" : "etcdoperator.v0.9.4",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.4",
-    "version": "0.9.4",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -310,9 +300,7 @@ $ cat etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.4-clusterwide",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.4-clusterwide",
-    "version": "0.9.4-clusterwide",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -371,9 +359,7 @@ $ cat community-operators/etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator-community.v0.6.1",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -407,9 +393,7 @@ $ cat community-operators/etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.0",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.0",
-    "version": "0.9.0",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -527,9 +511,7 @@ This information is currently captured in the `package` table.
 {
     "schema": "olm.bundle",
     "name": "<operatorbundle_name>",
-    "package": "<package_name>",
     "image": "<operatorbundle_path>",
-    "version": "<version>",
     "properties":["<list of properties of bundle that encode bundle dependencies(provided and required apis) upgrade graph info(skips/skipRange), and bundle channel/s info>"],
     "relatedImages" : ["<list-of-related-images>"]
 }
@@ -634,9 +616,7 @@ $ cat community-operators/etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator-community.v0.6.1",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -684,9 +664,7 @@ $ cat community-operators/etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator-community.v0.6.1",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -720,9 +698,7 @@ $ cat community-operators/etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.0",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.0",
-    "version": "0.9.0",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -772,9 +748,7 @@ $ cat community-operators/etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator-community.v0.6.1",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -820,9 +794,7 @@ $ cat community-operators/etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator-community.v0.6.1",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.6.1",
-    "version": "0.6.1",
     "properties":[
         {
             "type": "olm.package.provided",
@@ -856,9 +828,7 @@ $ cat community-operators/etcd.json
 {
     "schema": "olm.bundle",
     "name": "etcdoperator.v0.9.0",
-    "package": "etcd",
     "image": "quay.io/operatorhubio/etcd:v0.9.0",
-    "version": "0.9.0",
     "properties":[
         {
             "type": "olm.package.provided",

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -89,7 +89,7 @@ $ cat etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "channels": ["alpha", "singlenamespace-alpha", "clusterwide-alpha"],
+    "validChannelNames": ["alpha", "singlenamespace-alpha", "clusterwide-alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {
@@ -367,7 +367,7 @@ $ cat community-operators/etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "channels": ["alpha", "singlenamespace-alpha", "clusterwide-alpha"],
+    "validChannelNames": ["alpha", "singlenamespace-alpha", "clusterwide-alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {
@@ -519,10 +519,16 @@ The config file for each package will have a stream of json objects, representin
     "name": "<package-name>",
     "defaultChannel": "<channel-name>",
     "icon": "embedded or remote",
-    "channels": ["<list-of-channels-in-package>"],
+    "validChannelNames": ["<optional-list-of-channels-in-package>"],
     "description": "A message about the operator, a description of channels..."
 }
 ```
+
+If `validChannelNames` is non-empty, it will be used to validate channel entries defined by bundles.
+This can help index maintainers ensure that bundles do not accidentally mis-name their channels,
+which could lead to the inadvertent creation of new channels
+(e.g. adding a new `stable-v1.0` channel to a bundle when the intention is to add it to the existing `stable-1.0` channel).
+
 This information is currently captured in the `package` table.
 
 ##### Declarative Bundle Format
@@ -630,7 +636,7 @@ $ cat community-operators/etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "channels": ["alpha"],
+    "validChannelNames": ["alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {
@@ -681,7 +687,7 @@ $ cat community-operators/etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "channels": ["alpha", "singlenamespace-alpha"],
+    "validChannelNames": ["alpha", "singlenamespace-alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {
@@ -770,7 +776,7 @@ $ cat community-operators/etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "channels": ["alpha"],
+    "validChannelNames": ["alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {
@@ -819,7 +825,7 @@ $ cat community-operators/etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "channels": ["alpha", "singlenamespace-alpha"],
+    "validChannelNames": ["alpha", "singlenamespace-alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -554,9 +554,7 @@ These properties are:
 | `olm.skipRange`        | `string`                               | `{"type":"olm.skipRange", "value": "<0.9.4"}`                                                                             |
 | `olm.channel`          | `{ name, replaces string }`            | `{"type":"olm.channel", "value":{"name":"singlenamespace-alpha", "replaces":"etcdoperator.v0.9.2"}}`<br>`{"type":"olm.channel", "value":{"name":"clusterwide-alpha"}}`         |
 
-When serving bundles via the registry GRPC server, the `olm.package.provided` and `olm.gvk.provided` properties
-will also be served as `olm.package` and `olm.gvk` respectively, so that existing clients expecting the old names
-will continue to as expected.
+To support both old and new clients, `opm` will ensure that there are matching `olm.gvk`/`olm.gvk.provided` and `olm.package`/`olm.package.provided` properties present in bundle properties during build time and during validation. When all supported clients have been transitioned to understand the new property names, `olm.gvk` and `olm.package` will be retired.
 
 #### Representing the upgrade graph in the channel json blob
 

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -89,7 +89,6 @@ $ cat etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "validChannelNames": ["alpha", "singlenamespace-alpha", "clusterwide-alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {
@@ -367,7 +366,6 @@ $ cat community-operators/etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "validChannelNames": ["alpha", "singlenamespace-alpha", "clusterwide-alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {
@@ -519,16 +517,9 @@ The config file for each package will have a stream of json objects, representin
     "name": "<package-name>",
     "defaultChannel": "<channel-name>",
     "icon": "embedded or remote",
-    "validChannelNames": ["<optional-list-of-channels-in-package>"],
     "description": "A message about the operator, a description of channels..."
 }
 ```
-
-If `validChannelNames` is non-empty, it will be used to validate channel entries defined by bundles.
-This can help index maintainers ensure that bundles do not accidentally mis-name their channels,
-which could lead to the inadvertent creation of new channels
-(e.g. adding a new `stable-v1.0` channel to a bundle when the intention is to add it to the existing `stable-1.0` channel).
-
 This information is currently captured in the `package` table.
 
 ##### Declarative Bundle Format
@@ -640,7 +631,6 @@ $ cat community-operators/etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "validChannelNames": ["alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {
@@ -691,7 +681,6 @@ $ cat community-operators/etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "validChannelNames": ["alpha", "singlenamespace-alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {
@@ -780,7 +769,6 @@ $ cat community-operators/etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "validChannelNames": ["alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {
@@ -829,7 +817,6 @@ $ cat community-operators/etcd.json
         "base64data":"iVBORw0KGgoAAAANSUhEUgAAA.....",
         "mediatype":"image/png"
     },
-    "validChannelNames": ["alpha", "singlenamespace-alpha"],
     "description": "A message about etcd operator, a description of channels"
 }
 {

--- a/enhancements/declarative-index-config.md
+++ b/enhancements/declarative-index-config.md
@@ -873,12 +873,12 @@ Since the new `opm` binary will create configs on `add`, the new images will be 
 
 ```Dockerfile
 ENTRYPOINT ["/bin/opm"]
-CMD ["registry", "serve", "--config", "config.json"]
+CMD ["registry", "serve", "config.json"]
 ```
 
 To migrate existing index images built with the old configuration, all existing `opm index` commands that alter the index (i,e `opm index add --from-index`, `opm index prune`, `opm index prune-stranded` and `opm index rm`) will be enhanced to first let the corresponding operation through, and then check if the sqllite database exists in the index. If it does, the sqllite database will be converted over to package representations instead, the sqllite database will be deleted, and the new altered image will be built using the new configuration. `prune`, `prune-stranded` and `rm` sub-commands under the `opm index` command will also be marked for deprecation. If these sub-commands are used on an index that has already been migrated over to package representations, the operations will still be supported on these indexes with package representations for the period of time these sub-commands are marked as deprecated, until they are removed.      
  
-The `opm registry` command contains the same sub-commands as that of `opm index` (`add`, `prune`, `prune-stranded` and `rm`), but accepts a database file with the `--database` flag that it operators on (instead of a container image like the `opm index` command). A new flag `configs` will be introduced under `opm registry` that will accept a directory which contains the declarative representation of all the packages inside the index. All existing sub-commands of `opm registry` will be continued to be supported for performing operations on the declarative representations using the new `config` flag. The ability to perform `add`, `prune`, `prune-stranded` and `rm` using the `--database` flag will be removed. The only `opm registry` command that will continue to be supported using the `--database` flag is the `serve` command, which will also be marked for deprecation.     
+The `opm registry` command contains the same sub-commands as that of `opm index` (`add`, `prune`, `prune-stranded` and `rm`), but accepts a database file with the `--database` flag that it operators on (instead of a container image like the `opm index` command). The `opm registry` commands that accept a database flag will deprecate the `--database` flag and expect a positional argument that contains the path to the config directory or a specific config file. All existing sub-commands of `opm registry` will be continued to be supported for performing operations on the declarative config representation. The ability to perform `add`, `prune`, `prune-stranded` and `rm` using the `--database` flag will be removed. The only `opm registry` command that will continue to be supported for databases is the `serve` command. Using databases with `serve` will be deprecated.
 
 ## Test plan
 


### PR DESCRIPTION
After starting a WIP for the Declarative Index Config GRPC, I ran across a few possible ways to improve the spec.

### Simplify property format

I propose that we change the property format to be the following:

```go
type property struct {
    Type string `json:"type"`
    Value json.RawMessage `json:"value"`
}
```

This would make it possible to parse a bundle generically in a single pass, and the `value` field would only need to be parsed further if a particular component needs information about a certain property.

This would change the examples currently in the EP in the following ways:
1. `property.name` is renamed to `property.type`.
1. The old `property.type` is removed. It should be included in the new `property.type` field (e.g. `name: "olm.gvk", type: "required"` becomes `type: "olm.gvk.required"`).
1. `property.replaces` is moved into the `property.value` data for the `olm.channel` property type.
1. `property.values` is removed. `property.value` can be any valid JSON and its particular schema is dictated by `property.type`.

### Rename `olm.package` to `olm.package.provided` and add example for `olm.package.required` property.

We need a new property type to encode required packages. This type would be slightly different than the `olm.package.provided` type because `olm.package.provided` uses a semver version field, and this type would need a semver version range field. 

I added an example of this property in the EP in the example bundle containing a required API.

For backwards compatibility reasons, we will continue to serve properties and dependencies by their old names in the GRPC API.

### File parsing concerns

I made the examples consistent to show that each config file is expected to be a stream of "schema":"olm.package" and "schema":"olm.bundle" JSON documents, with no commas between them, and no root list of these objects. This will make parsing fairly straightforward and make it easy for users and tools to concatenate new items to existing config files. For example:

```
cat my-operator.v2.0.0.json >> my-index.json
```

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>