### PR TITLE
enhancements: Update the upstream/downstream OLM enhancement

### DIFF
--- a/enhancements/upstream-downstream-repository-split.md
+++ b/enhancements/upstream-downstream-repository-split.md
@@ -13,7 +13,7 @@ approvers:
   - "@krizza"
   - "@njhale"
 creation-date: 2020-11-20
-last-updated: 2020-03-01
+last-updated: 2020-03-23
 status: implementable
 ---
 
@@ -35,6 +35,7 @@ OLM currently follows the OpenShift release cycle, due to which there are period
 This proposal describes a way to support both upstream and downstream development by splitting the OLM codebase into upstream and downstream repositories. Both types of repositories will be able to accept changes without blocking the other, and a sync process is defined to allow changes from one type of repository to flow to the other.
 
 ### Goals
+
 - Define the structure of upstream and downstream repositories
 - Have upstream development be independent from downstream decisions or state
 - Enable unblocked development for downstream regardless of state of upstream repositories
@@ -44,6 +45,7 @@ This proposal describes a way to support both upstream and downstream developmen
 - Minimize disruption to regular development during migration period
 
 ### Non-Goals
+
 - Automation for downstreaming, backporting or otherwise interacting between upstream and downstream
 - Zero OpenShift-specific code in upstream from day 1
 - Changes to downstream conformance testing
@@ -61,21 +63,27 @@ The manual upstreaming and downstreaming process will be assisted by a set of he
 ### User Stories
 
 #### Unblocked development for downstream
+
 As an OLM developer, I want to make changes to downstream code without being blocked by upstream.
 
 #### Independent development for upstream
+
 As an upstream contributor, I want to make contributions without depending on downstream.
 
 #### Sync downstream with upstream
+
 As an OLM developer, I want to bring upstream changes to downstream.
 
 #### Bring changes to upstream
+
 As an OLM developer, I want to bring specific downstream changes to upstream for community review.
 
 #### Backport changes to previous downstream releases
+
 As an OLM developer, I want to backport specific changes to the previous [n-2] downstream release branches.
 
 #### Build from downstream
+
 As an OLM developer, I want to build release artifacts for downstream.
 
 ### Implementation Details
@@ -85,13 +93,16 @@ The OLM code base will be split into upstream and downstream repositories. Downs
 #### Upstream repositories
 
 The upstream codebase will continue to live in the [operator framework](https://github.com/operator-framework/) github org. The repositories chosen for the split will have the OpenShift based tests disabled once the downstream repo builds are healthy. These are the current list of repositories in the split:
+
 - [operator-framework/api](https://github.com/operator-framework/api)
 - [operator-framework/operator-registry](https://github.com/operator-framework/operator-registry)
 - [operator-framework/operator-lifecycle-manager](https://github.com/operator-framework/operator-lifecycle-manager)
 
 ### Downstream repository layout
 
-The downstream monorepo will live at a new repo openshift/operator-framework-olm. The upstream projects will be present as vendored directories.
+The downstream monorepo will live in a new repository, openshift/operator-framework-olm.
+
+The upstream projects will be then present as vendored directories:
 
 ``` yaml
 .
@@ -125,27 +136,24 @@ The downstream monorepo will live at a new repo openshift/operator-framework-olm
 ```
 
 The main components of the repository are as follows:
+
 - staging: The upstream repositories are vendored into subdirectories using `git subtree`. These contain the upstream code, along with downstream specific changes.
 - pkg: Any downstream only changes that do not need to be upstreamed or backported reside in this directory.
 - downstream build files: The downstream repository will have common build dependencies, including a unified `Makefile`, `go.mod`, `go.sum` and `vendor` directory present at the repo root. This also includes multiple `Dockerfiles` that will be used for building downstream artifacts.
 - scripts: This will contain helper scripts for maintaining the upstream and downstream repos.
-    - add\_repo.sh: This is used to add a new upstream project to be tracked. It also ensures the remotes are added to the local git repository. To track the [operator-framework/api](github.com/operator-framework/api), the `add_repo.sh` script can be called as shown. This also adds a new remote `api` to the local git repository and adds `operator-framework/api` to the list of tracked remotes.
-      ```
-      $ ./scripts/add_repo.sh operator-framework/api
-      ```
-    - push\_upstream.sh: This script allows certain commits or commit ranges from downstream master to an upstream repo, a PR will be opened from a newly created upstream branch against the corresponding master. Pushing changes to upstream will require that they are accepted on the downstream master branch. Commits made to older release branches will therefore not be supported by the `push_upstream.sh` script. If commit ID is omitted, the HEAD of the downstream subtree is pushed instead.
-      ```
-      $ ./scripts/push_upstream.sh api b548a718f..85784b751
-      ```
-       This will create a PR against `operator-framework/api:master` from a new branch `api-b548a7-1605884019`.
+  - add\_repo.sh: This is used to add a new upstream project to be tracked. It also ensures the remotes are added to the local git repository. To track the [operator-framework/api](github.com/operator-framework/api), the `add_repo.sh` script can be called as shown. This also adds a new remote `api` to the local git repository and adds `operator-framework/api` to the list of tracked remotes.
 
-  - pull\_upstream.sh: When run, this pulls all changes from an upstream repository. The specific subtree meant to be pulled can be provided as an argument, along with an upstream branch to pull from. The changes will be merged to a new local branch from which a PR will be opened to downstream/master. If no arguments are passed, the script will sync all the vendored repositories in the `staging` directory.
+    ```bash
+    ./scripts/add_repo.sh operator-framework/api
     ```
-    $ ./scripts/pull_upstream.sh api
+
+  - push\_upstream.sh: This script allows certain commits or commit ranges from downstream master to an upstream repo, a PR will be opened from a newly created upstream branch against the corresponding master. Pushing changes to upstream will require that they are accepted on the downstream master branch. Commits made to older release branches will therefore not be supported by the `push_upstream.sh` script. If commit ID is omitted, the HEAD of the downstream subtree is pushed instead.
+
+    ```bash
+    ./scripts/push_upstream.sh api b548a718f..85784b751
     ```
     During the upstream merge process, any conflicts will require human intervention to resolve.
-  - manifests:
-
+  - manifests: Contains the list of YAML manifests that are needed by the [CVO to deploy](https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/operators.md) OLM and the operator-registry resources and roles.
 ### Downstreaming
 1. Change PRs merge to upstream/master.
 2. The upstream sync runs manually for the vendored subtrees. This will create a PR against downstream/master except when downstream/master is closed for development, sync will be run daily to decrease the changes being merged at once.

--- a/enhancements/upstream-downstream-repository-split.md
+++ b/enhancements/upstream-downstream-repository-split.md
@@ -91,7 +91,7 @@ The upstream codebase will continue to live in the [operator framework](https://
 
 ### Downstream repository layout
 
-The downstream monorepo will live at a new repo openshift/operator-lifecycle-manager. The upstream projects will be present as vendored directories.
+The downstream monorepo will live at a new repo openshift/operator-framework-olm. The upstream projects will be present as vendored directories.
 
 ``` yaml
 .
@@ -199,11 +199,11 @@ Backports to older versions of OpenShift may be blocked if the corresponding ups
 
 ### Test Plan
 
-create a downstream monorepo in `openshift/operator-lifecycle-manager`, vendor mirrors of the other repositories as subtrees. Do not update the build source at this stage
+create a downstream monorepo in `openshift/operator-framework-olm`, vendor mirrors of the other repositories as subtrees. Do not update the build source at this stage
 ensure that builds can succeed from the monorepo.
 do nightly sync with the upstream repos to ensure that the downstreaming process works as intended
 test a backport of a commit, both to another branch on the monorepo and to the mirrored repositories
-Update `openshift/release` to use `openshift/operator-lifecycle-manager` as its build source, ensure successful build
+Update `openshift/release` to use `openshift/operator-framework-olm` as its build source, ensure successful build
 
 ### Upgrade / Downgrade Strategy
 
@@ -236,4 +236,4 @@ The downstream product may also be a set of forks of corresponding upstream proj
 
 ## Infrastructure Needed
 
-- New downstream repository, `openshift/operator-lifecycle-manager`.
+- New downstream repository, `openshift/operator-framework-olm`.


### PR DESCRIPTION
Updated the name of the repository from `openshift/operator-lifecycle-manager` to `openshift/operator-framework-olm`.

The `manifests/` directory description was previously missing. Updated to attempt to explain why those manifests are needed by the CVO.

Fixed any markdown violations throughout the enhancement.