### PR TITLE
enhancement: External validations for Operator SDK

### DIFF
--- a/enhancements/sdk-external-and-pluggable-validations.md
+++ b/enhancements/sdk-external-and-pluggable-validations.md
@@ -27,20 +27,21 @@ see-also:
 
 ## Open Questions [optional]
 
- 1. what validations do we have today?
  1. can we use scorecard to replace all of these validations?
     * scorecard uses the cluster to run the tests, these validations typically
       run locally or in a pipeline. They are also done before the expensive
       operator tests are run.
  1. what would it take to convert an existing validator to an executable format?
+    Simply add a `main.go` to wrap existing validators.
+ 1. do we need to add `json` tags to [these structs][errors-go]?
 
 ## Summary
 
-Today, validations used by CVP are compiled into the operator-sdk. Any changes
+Today, validations used by CVP are compiled into the `operator-sdk`. Any changes
 to the validation rules requires a release of operator-framework/api followed by
-a release of operator-sdk. This proposal attempts to design a way where the
+a release of `operator-sdk`. This proposal attempts to design a way where the
 validations can be hosted in their own repos as well as updated without
-requiring new releases of the operator-sdk.
+requiring new releases of the `operator-sdk`.
 
 ## Motivation
 
@@ -66,8 +67,6 @@ validators to be created allowing for greater flexibility.
 * allow validations to be hosted in their own repos
 * allow validations to be external to operator-sdk
 
-TODO: are there any other goals?
-
 ### Non-Goals
 
 * existing validations do NOT have be migrated unless they want to
@@ -83,8 +82,6 @@ TODO: are there any other goals?
 #### Story 2
 * as a validation author, I can write a validation for a bundle and use it
   without having to get a new operator-sdk release
-
-TODO: Stories from the epic; consolidate with the above stories
 
 #### Story 3
 * Users want to edit/add/remove a set of validation rules for Operator bundle validation.
@@ -121,9 +118,6 @@ shell script.
 
 From the operator-sdk's point of view, we don't care what you use
 to create your validator only that we can run it and pass it a bundle directory.
-
-
-TODO: how will validators be found?
 
 #### Validators
 
@@ -220,8 +214,6 @@ be found at [validator-poc][validator-poc1]
 Another example of a migration can be find at [ocp-olm-catalog-validator][camila-poc].
 This particular example does NOT yet output `ManifestResult` format.
 
-TODO: do we need to add `json` tags to these structs?
-https://github.com/operator-framework/api/blob/master/pkg/validation/errors/error.go#L9-L16
 
 
 #### CLI
@@ -238,6 +230,7 @@ Usage:
 ...
 
 Flags:
+      --alpha-select-external string                         Selector to select external validators to run. It should be set to a Unix path list ("/path/to/e1.sh:/path/to/e2")
   -h, --help                                                 help for validate
   -b, --image-builder string                                 Tool to pull and unpack bundle images. Only used when validating a bundle image. One of: [docker, podman, none] (default "docker")
       --list-optional                                        List all optional validators available. When set, no validators will be run
@@ -253,93 +246,12 @@ Global Flags:
 * *--help* works as is
 * *--image-builder* works as is
 * *--list-optional* would need to be updated to locate external validators.
-
-  TODO: How do we locate these validators? Do we use the XDG_CONFIG like Phase
-  2? Or allow users to pass in the location of the validators?
-
 * *--optional-values* would continue to be passed to the validators
 * *--output* indicates how we want to output the results.
+* *--select-optional* works as is
+* *-- alpha-select-external* added; takes in the location of the executable to run as
+  the validator, i.e. `/path/to/validator/the-executable:/path/to/another`
 
-  TODO: what types do we want to support?
-
-* *--select-optional* takes in a label selector to specify which optional test
-  to run. We could allow a new label to indicate the location of the executable
-  to run as the validator. i.e. `validator-path=/path/to/validator/the-executable`
-
-TODO: need to define what the CLI for operator-sdk will look like. Are there
-any new flags? Do we use the environment variable?
-
-NOTE: what would the CLI look like?
-
-
-##### Default validators run by operator-sdk
-
-List of current validators:
-TODO: do we need these validators called out like this?
-
-* BundleValidator
-  * validates the bundle
-  * looks for duplicate keys in bundle
-  * verifies all owned keys match a CRD in the bundle
-  * verifies that all CRDs present in the bundle are in the CSV
-  * validates the service account
-
-* ClusterServiceVersionValidator
-  * operator-sdk checks to see if the CSV is nil on the bundle (that's the first
-    check)
-  * checks that the CSV name is a valid format
-    * DNS1123
-    * valid label
-  * verifies replaces name is also a valid format
-    * DNS1123
-    * valid label
-  * ensures that both `alm-examples` and `olm.examples` are not both present
-  * decodes the example yaml, to validate its format
-  * checks provided APIs
-  * validates the `InstallModes`
-    * verifies that conversion CRDs support `AllNamespaces`
-  * checks for missing mandatory fields
-  * validates the annotation names
-  * validates the version and kind
-
-* CustomResourceDefinitionValidator
-  * operator-sdk puts the v1beta1 and v1 CRDs together for validation
-  * validates v1beta1 CRDs
-  * validates v1 CRDs
-  * validates internal CRDs
-    * https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apis/apiextensions/validation/validation.go#L49-L78
-
-##### Optional validators
-
-* PackageManifestValidator
-
-* OperatorHubValidator
-
-* ObjectValidator
-
-* OperatorGroupValidator
-
-* CommunityOperatorValidator
-
-* AlphaDeprecatedAPIsValidator
-
-* AllValidators
-  * Uses ALL of the validators
-    * BundleValidator
-    * ClusterServiceVersionValidator
-    * CustomResourceDefinitionValidator
-    * PackageManifestValidator
-    * OperatorHubValidator
-    * ObjectValidator
-    * OperatorGroupValidator
-    * CommunityOperatorValidator
-    * AlphaDeprecatedAPIsValidator
-
-* DefaultBundleValidators
-  * Uses the following 3 validators
-    * BundleValidator
-    * ClusterServiceVersionValidator
-    * CustomResourceDefinitionValidator
 ### Risks and Mitigations
 
 There is little risk, if this does not pan out we keep going on the current path
@@ -349,73 +261,17 @@ of compiling them in.
 
 ### Test Plan
 
-**Note:** *Section not required until targeted at a release.*
-
-Consider the following in developing a test plan for this enhancement:
-- Will there be e2e and integration tests, in addition to unit tests?
-- How will it be tested in isolation vs with other components?
-
-No need to outline all of the test cases, just the general strategy. Anything
-that would count as tricky in the implementation and anything particularly
-challenging to test should be called out.
-
-All code is expected to have adequate tests (eventually with coverage
-expectations).
+- unit tests for the feature will be added in the implementation
+- QE would need to create custom validations to be called by the new `--alpha-select-external` flag.
 
 ### Graduation Criteria
 
-**Note:** *Section not required until targeted at a release.*
+This feature will come out as alpha accessible via the `--alpha-select-external`
+flag to the `bundle validate` command. We will accept feedback on possible
+changes to the feature.
 
-Define graduation milestones.
-
-These may be defined in terms of API maturity, or as something else. Initial proposal
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
-
-Consider the following in developing the graduation criteria for this
-enhancement:
-- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
-- Deprecation
-
-Clearly define what graduation means.
-
-#### Examples
-
-These are generalized examples to consider, in addition to the aforementioned
-[maturity levels][maturity-levels].
-
-##### Dev Preview -> Tech Preview
-
-- Ability to utilize the enhancement end to end
-- End user documentation, relative API stability
-- Sufficient test coverage
-- Gather feedback from users rather than just developers
-
-##### Tech Preview -> GA 
-
-- More testing (upgrade, downgrade, scale)
-- Sufficient time for feedback
-- Available by default
-
-**For non-optional features moving to GA, the graduation criteria must include
-end to end tests.**
-
-##### Removing a deprecated feature
-
-- Announce deprecation and support policy of the existing feature
-- Deprecate the feature
-
-### Upgrade / Downgrade Strategy
-
-If applicable, how will the component be upgraded and downgraded? Make sure this
-is in the test plan.
-
-Consider the following in developing an upgrade/downgrade strategy for this
-enhancement:
-- What changes (in invocations, configurations, API use, etc.) is an existing
-  cluster required to make on upgrade in order to keep previous behavior?
-- What changes (in invocations, configurations, API use, etc.) is an existing
-  cluster required to make on upgrade in order to make use of the enhancement?
+After a period of time, we can graduate to a GA with a more permanent flag, i.e.
+`--select-external`.
 
 ### Version Skew Strategy
 
@@ -426,8 +282,7 @@ enhancement:
 
 ## Implementation History
 
-Major milestones in the life cycle of a proposal should be tracked in `Implementation
-History`.
+N/A
 
 ## Drawbacks
 
@@ -445,20 +300,6 @@ compilation step being needed depending on the language used to implement them.
   * con:
     * would need a cluster to run these validations
     * authors would have to create binaries of their validations anyway
-
-TODO: ---------- vvvvvv CUT vvvvvv ----------
-* wrap validations in their own executables
-  * validations would be wrapped in an executable that would be called from
-    operator-sdk
-  * pro:
-    * could reuse the existing go validations and put a main.go in front to make
-      them executable
-    * follows a similar phase 2 plugin path
-    * could reuse some of the phase 2 tech to run this
-    * would not need a cluster necessarily to run the validation
-  * con:
-    * authors would have to create binaries of their validations
-TODO: ---------- ^^^^^^ CUT ^^^^^^ ----------
 
 * use a language like JavaScript or CUE to define all validations
   * validations could be run from a git repo, i.e. operator-sdk could pull it
@@ -480,15 +321,10 @@ TODO: ---------- ^^^^^^ CUT ^^^^^^ ----------
 
 ## Infrastructure Needed [optional]
 
-Use this section if you need things from the project. Examples include a new
-subproject, repos requested, github details, and/or testing infrastructure.
-
-Listing these here allows the community to get the process for these resources
-started right away.
-
-https://github.com/operator-framework/api/tree/master/pkg/validation
+N/A
 
 [phase-2]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-2.md
 [manifest-result]: https://github.com/operator-framework/api/blob/master/pkg/validation/errors/error.go#L9-L16
 [validator-poc1]: https://github.com/jmrodri/validator-poc/tree/poc1-manifestresults
 [camila-poc]: https://github.com/camilamacedo86/ocp-olm-catalog-validator
+[errors-go]: https://github.com/operator-framework/api/blob/master/pkg/validation/errors/error.go#L9-L16

--- a/enhancements/sdk-external-and-pluggable-validations.md
+++ b/enhancements/sdk-external-and-pluggable-validations.md
@@ -37,11 +37,11 @@ see-also:
 
 ## Summary
 
-Today, validations used by CVP are compiled into the `operator-sdk`. Any changes
-to the validation rules requires a release of operator-framework/api followed by
-a release of `operator-sdk`. This proposal attempts to design a way where the
-validations can be hosted in their own repos as well as updated without
-requiring new releases of the `operator-sdk`.
+Today, validations used by Container Verification Pipeline (CVP) are compiled into
+the `operator-sdk`. Any changes to the validation rules requires a release of
+operator-framework/api followed by a release of `operator-sdk`. This proposal
+attempts to design a way where the validations can be hosted in their own repos
+as well as updated without requiring new releases of the `operator-sdk`.
 
 ## Motivation
 

--- a/enhancements/sdk-external-and-pluggable-validations.md
+++ b/enhancements/sdk-external-and-pluggable-validations.md
@@ -43,6 +43,39 @@ operator-framework/api followed by a release of `operator-sdk`. This proposal
 attempts to design a way where the validations can be hosted in their own repos
 as well as updated without requiring new releases of the `operator-sdk`.
 
+The validator is defined in the operator-framework/api, for example here is the
+[`OperatorHubValidator`][operator-hub-validator]. In the `operator-sdk`, it is
+"registered" as an optional validator.
+
+```go
+var optionalValidators = validators{
+	{
+		Validator: apivalidation.OperatorHubValidator,
+		name:      "operatorhub",
+		labels: map[string]string{
+			nameKey:  "operatorhub",
+			suiteKey: "operatorframework",
+		},
+		desc: "OperatorHub.io metadata validation. ",
+	},
+    ...
+```
+
+When the validators are specified on the CLI, we call `run()` on the
+[validators][optional-validators]. In that `run()` method we loop through the
+validaors specified by `vals`. On each validator we invoke `Validate` with the
+list of objects to validate.
+
+```go
+    ...
+    for _, v := range vals {
+		if sel.Matches(labels.Set(v.labels)) {
+			results = append(results, v.Validate(objs...)...)
+		}
+	}
+    ...
+```
+
 ## Motivation
 
 Every time the business changes validation rules, it requires an update to the
@@ -339,3 +372,5 @@ N/A
 [validator-poc1]: https://github.com/jmrodri/validator-poc/tree/poc1-manifestresults
 [camila-poc]: https://github.com/camilamacedo86/ocp-olm-catalog-validator
 [errors-go]: https://github.com/operator-framework/api/blob/master/pkg/validation/errors/error.go#L9-L16
+[operator-hub-validator]: https://github.com/operator-framework/api/blob/master/pkg/validation/internal/operatorhub.go
+[optional-validator]: https://github.com/operator-framework/operator-sdk/blob/master/internal/cmd/operator-sdk/bundle/validate/optional.go#L130-L156

--- a/enhancements/sdk-external-and-pluggable-validations.md
+++ b/enhancements/sdk-external-and-pluggable-validations.md
@@ -262,6 +262,12 @@ Global Flags:
 There is little risk, if this does not pan out we keep going on the current path
 of compiling them in.
 
+Another possible risk is users of an airgapped environment will have to install
+these external validator executables. We could supply a mechanism for
+distributing these external validators as an image. For this first release, we
+will ignore the distribution solutions leaving it to the user to copy the
+validators onto the system running `operator-sdk`.
+
 ## Design Details
 
 ### Test Plan

--- a/enhancements/sdk-external-and-pluggable-validations.md
+++ b/enhancements/sdk-external-and-pluggable-validations.md
@@ -61,15 +61,15 @@ validators to be created allowing for greater flexibility.
 
 ### Goals
 
-* allow validations to be updated when the business needs them to be
-* allow validations to release when the authors need them to be
-* do not require newer builds of the operator-sdk to get updated rules
-* allow validations to be hosted in their own repos
-* allow validations to be external to operator-sdk
+* Allow validations to be updated when the business needs them to be
+* Allow validations to release when the authors need them to be
+* Do not require newer builds of the operator-sdk to get updated rules
+* Allow validations to be hosted in their own repos
+* Allow validations to be external to operator-sdk
 
 ### Non-Goals
 
-* existing validations do NOT have be migrated unless they want to
+* Migrate existing validators to the new format
 
 ## Proposal
 

--- a/enhancements/sdk-external-and-pluggable-validations.md
+++ b/enhancements/sdk-external-and-pluggable-validations.md
@@ -145,6 +145,11 @@ A concrete example might look like this:
 The actual implementation is up to the author. Here we have an example of
 the [`OperatorHubValidator`][validator-poc1] as a Go binary.
 
+The validators can be written in any language but there must be an executable
+entry point that accepts a single bundle path as a CLI argument. For example,
+you can write your validator in python but you would want to make the main
+python file executable or supply a shell script to be invoked.
+
 ##### Validator results
 
 As stated earlier, each validator should be some executable that accepts a

--- a/enhancements/sdk-external-and-pluggable-validations.md
+++ b/enhancements/sdk-external-and-pluggable-validations.md
@@ -1,0 +1,204 @@
+---
+title: sdk-external-and-pluggable-validations
+authors:
+  - "@jmrodri"
+reviewers:
+  - TBD
+  - "@camila"
+  - "@joe"
+approvers:
+  - TBD
+  - "@camila"
+  - "@joe"
+creation-date: 2021-10-01
+last-updated: 2021-10-01
+status: implementable
+see-also:
+  - "/enhancements/this-other-neat-thing.md"
+---
+
+# SDK External and Pluggable Validations
+
+## Release Signoff Checklist
+
+- [ ] Enhancement is `implementable`
+- [ ] Design details are appropriately documented from clear requirements
+- [ ] Test plan is defined
+- [ ] Graduation criteria for dev preview, tech preview, GA
+
+## Open Questions [optional]
+
+This is where to call out areas of the design that require closure before deciding
+to implement the design.  For instance,
+ > 1. This requires exposing previously private resources which contain sensitive
+  information.  Can we do this?
+
+## Summary
+
+Today, validations used by CVP are compiled into the operator-sdk. Any changes
+to the validation rules requires a release of operator-framework/api followed by
+a release of operator-sdk. This proposal attempts to design a way where the
+validations can be hosted in their own repos as well as updated without
+requiring new releases of the operator-sdk.
+
+## Motivation
+
+Every time the business changes validation rules, it requires an update to the
+operator-framework/api library. A release of said library, then it needs to get
+included into the operator-sdk. Then a release of the SDK needs to be cut in
+order for the new validation rule change to be usable.
+
+This process slows down the business by having to wait for this release process
+to occur for what could be a very small rule change. It also causes downstream
+rules to require an immediate upstream operator-sdk release which may be as far
+as 3 weeks away.
+
+### Goals
+
+List the specific goals of the proposal. How will we know that this has succeeded?
+
+### Non-Goals
+
+What is out of scope for this proposal? Listing non-goals helps to focus discussion
+and make progress.
+
+## Proposal
+
+This is where we get down to the nitty gritty of what the proposal actually is.
+
+### User Stories [optional]
+
+Detail the things that people will be able to do if this is implemented.
+Include as much detail as possible so that people can understand the "how" of
+the system. The goal here is to make this feel real for users without getting
+bogged down.
+
+#### Story 1
+
+#### Story 2
+
+### Implementation Details/Notes/Constraints [optional]
+
+What are the caveats to the implementation? What are some important details that
+didn't come across above. Go in to as much detail as necessary here. This might
+be a good place to talk about core concepts and how they releate.
+
+### Risks and Mitigations
+
+What are the risks of this proposal and how do we mitigate. Think broadly. For
+example, consider both security and how this will impact the larger Operator Framework
+ecosystem.
+
+How will security be reviewed and by whom? How will UX be reviewed and by whom?
+
+Consider including folks that also work outside your immediate sub-project.
+
+## Design Details
+
+### Test Plan
+
+**Note:** *Section not required until targeted at a release.*
+
+Consider the following in developing a test plan for this enhancement:
+- Will there be e2e and integration tests, in addition to unit tests?
+- How will it be tested in isolation vs with other components?
+
+No need to outline all of the test cases, just the general strategy. Anything
+that would count as tricky in the implementation and anything particularly
+challenging to test should be called out.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations).
+
+### Graduation Criteria
+
+**Note:** *Section not required until targeted at a release.*
+
+Define graduation milestones.
+
+These may be defined in terms of API maturity, or as something else. Initial proposal
+should keep this high-level with a focus on what signals will be looked at to
+determine graduation.
+
+Consider the following in developing the graduation criteria for this
+enhancement:
+- Maturity levels - `Dev Preview`, `Tech Preview`, `GA`
+- Deprecation
+
+Clearly define what graduation means.
+
+#### Examples
+
+These are generalized examples to consider, in addition to the aforementioned
+[maturity levels][maturity-levels].
+
+##### Dev Preview -> Tech Preview
+
+- Ability to utilize the enhancement end to end
+- End user documentation, relative API stability
+- Sufficient test coverage
+- Gather feedback from users rather than just developers
+
+##### Tech Preview -> GA 
+
+- More testing (upgrade, downgrade, scale)
+- Sufficient time for feedback
+- Available by default
+
+**For non-optional features moving to GA, the graduation criteria must include
+end to end tests.**
+
+##### Removing a deprecated feature
+
+- Announce deprecation and support policy of the existing feature
+- Deprecate the feature
+
+### Upgrade / Downgrade Strategy
+
+If applicable, how will the component be upgraded and downgraded? Make sure this
+is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for this
+enhancement:
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade in order to keep previous behavior?
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade in order to make use of the enhancement?
+
+### Version Skew Strategy
+
+How will the component handle version skew with other components?
+What are the guarantees? Make sure this is in the test plan.
+
+Consider the following in developing a version skew strategy for this
+enhancement:
+- During an upgrade, we will always have skew among components, how will this impact your work?
+- Does this enhancement involve coordinating behavior in the control plane and
+  in the kubelet? How does an n-2 kubelet without this feature available behave
+  when this feature is used?
+- Will any other components on the node change? For example, changes to CSI, CRI
+  or CNI may require updating that component before the kubelet.
+
+## Implementation History
+
+Major milestones in the life cycle of a proposal should be tracked in `Implementation
+History`.
+
+## Drawbacks
+
+The idea is to find the best form of an argument why this enhancement should _not_ be implemented.
+
+## Alternatives
+
+Similar to the `Drawbacks` section the `Alternatives` section is used to
+highlight and record other possible approaches to delivering the value proposed
+by an enhancement.
+
+## Infrastructure Needed [optional]
+
+Use this section if you need things from the project. Examples include a new
+subproject, repos requested, github details, and/or testing infrastructure.
+
+Listing these here allows the community to get the process for these resources
+started right away.
+

--- a/enhancements/sdk-external-and-pluggable-validations.md
+++ b/enhancements/sdk-external-and-pluggable-validations.md
@@ -27,10 +27,9 @@ see-also:
 
 ## Open Questions [optional]
 
-This is where to call out areas of the design that require closure before deciding
-to implement the design.  For instance,
- > 1. This requires exposing previously private resources which contain sensitive
-  information.  Can we do this?
+ 1. what validations do we have today?
+ 1. do these validations run against a cluster?
+ 1. can we use scorecard to replace all of these validations?
 
 ## Summary
 
@@ -85,11 +84,46 @@ bogged down.
 
 ### Implementation Details/Notes/Constraints [optional]
 
-What are the caveats to the implementation? What are some important details that
-didn't come across above. Go in to as much detail as necessary here. This might
-be a good place to talk about core concepts and how they releate.
+* put validations in their own images
+  * need to define "API" contract what is the entrypoint and what parameters do
+    we give it
+  * pro:
+    * already have a precendence for running things from images
+    * familiar tech
+    * could run locally and simply use the image as a data transport
+  * con:
+    * would need a cluster to run these validations
+    * authors would have to create binaries of their validations
 
+* wrap validations in their own executables
+  * validations would be wrapped in an executable that would be called from
+    operator-sdk
+  * pro:
+    * could reuse the existing go validations and put a main.go in front to make
+      them executable
+    * follows a similar phase 2 plugin path
+    * could reuse some of the phase 2 tech to run this
+    * would not need a cluster necessarily to run the validation
+  * con:
+    * authors would have to create binaries of their validations
 
+* use a language like JavaScript or CUE to define all validations
+  * validations could be run from a git repo, i.e. operator-sdk could pull it
+    and then evaluate it
+  * pro:
+    * simpler delivery, expose via a gitrepo and done
+  * con:
+    * all existing validations would have to be re-written in new language
+      structure which could introduce new bugs
+    * unproven technology
+    * would have to write the engine to know how to execute these
+
+* use scorecard to do the validations
+  * create validations written in scorecard as custom tests
+  * pro:
+    * infrastructure required to run is already built within scorecard
+  * con:
+    * would need a cluster to run these validations
 
 
 ### Risks and Mitigations
@@ -211,3 +245,4 @@ subproject, repos requested, github details, and/or testing infrastructure.
 Listing these here allows the community to get the process for these resources
 started right away.
 
+https://github.com/operator-framework/api/tree/master/pkg/validation

--- a/enhancements/sdk-external-and-pluggable-validations.md
+++ b/enhancements/sdk-external-and-pluggable-validations.md
@@ -27,13 +27,13 @@ see-also:
 
 ## Open Questions [optional]
 
- 1. can we use scorecard to replace all of these validations?
-    * scorecard uses the cluster to run the tests, these validations typically
+ 1. Can we use scorecard to replace all of these validations?
+    * Scorecard uses the cluster to run the tests, these validations typically
       run locally or in a pipeline. They are also done before the expensive
       operator tests are run.
- 1. what would it take to convert an existing validator to an executable format?
+ 1. What would it take to convert an existing validator to an executable format?
     Simply add a `main.go` to wrap existing validators.
- 1. do we need to add `json` tags to [these structs][errors-go]?
+ 1. Do we need to add `json` tags to [these structs][errors-go]?
 
 ## Summary
 
@@ -103,6 +103,7 @@ validators to be created allowing for greater flexibility.
 ### Non-Goals
 
 * Migrate existing validators to the new format
+* The distribution of the external validators
 
 ## Proposal
 
@@ -249,10 +250,10 @@ stdout.
 An example POC that takes an existing validator and outputs `ManifestResult` can
 be found at [validator-poc][validator-poc1]
 
-Another example of a migration can be find at [ocp-olm-catalog-validator][camila-poc].
-This particular example does NOT yet output `ManifestResult` format.
-
-
+Another pair of examples of a migration can be found at
+[ocp-olm-catalog-validator][ocp-olm-catalog-valdator] and at
+[the k8s-bundle-validator][k8s-bundle-validator]. These particular examples do NOT
+yet output `ManifestResult` format.
 
 #### CLI
 
@@ -362,6 +363,8 @@ compilation step being needed depending on the language used to implement them.
     * infrastructure required to run is already built within scorecard
   * con:
     * would need a cluster to run these validations
+    * because of cluster, tests would require 3 minutes to be executed
+    * would make it very time consuming and difficult to run from Audit Tool
 
 ## Infrastructure Needed [optional]
 
@@ -370,7 +373,8 @@ N/A
 [phase-2]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-2.md
 [manifest-result]: https://github.com/operator-framework/api/blob/master/pkg/validation/errors/error.go#L9-L16
 [validator-poc1]: https://github.com/jmrodri/validator-poc/tree/poc1-manifestresults
-[camila-poc]: https://github.com/camilamacedo86/ocp-olm-catalog-validator
 [errors-go]: https://github.com/operator-framework/api/blob/master/pkg/validation/errors/error.go#L9-L16
 [operator-hub-validator]: https://github.com/operator-framework/api/blob/master/pkg/validation/internal/operatorhub.go
 [optional-validator]: https://github.com/operator-framework/operator-sdk/blob/master/internal/cmd/operator-sdk/bundle/validate/optional.go#L130-L156
+[ocp-olm-catalog-validator]: https://github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator
+[k8s-bundle-validator]: https://github.com/k8s-operatorhub/bundle-validator

--- a/enhancements/sdk-external-and-pluggable-validations.md
+++ b/enhancements/sdk-external-and-pluggable-validations.md
@@ -55,9 +55,10 @@ rules to require an immediate upstream operator-sdk release, which may
 otherwise be as far as 3 weeks away. It is difficult to explain to the community
 why we need a new release for a CVP need.
 
-### Goals
+Having the validators external to the SDK will allow for vendor specific
+validators to be created allowing for greater flexibility.
 
-List the specific goals of the proposal. How will we know that this has succeeded?
+### Goals
 
 * allow validations to be updated when the business needs them to be
 * allow validations to release when the authors need them to be
@@ -69,8 +70,7 @@ TODO: are there any other goals?
 
 ### Non-Goals
 
-TODO: What is out of scope for this proposal? Listing non-goals helps to focus discussion
-and make progress.
+* existing validations do NOT have be migrated unless they want to
 
 ## Proposal
 
@@ -101,14 +101,14 @@ There are a few alternatives, but I think wrapping the validations in their
 own executables makes sense. It aligns with the work we've done with
 [Phase 2][phase-2] plugins. It allows the most flexibility in terms of
 implementation. It also has a simple API -
-input: bundle dir; output: ManifestErrors JSON.
+input: bundle dir; output: ManifestResult JSON.
 
 Wrapping validations in their own executable simply means that there
 needs to be something that the operator-sdk can run like a shell script
 or a binary.
 
 The validation executable will need to accept a single input value which
-is the bundle directory. The output will need to be a ManifestErrors JSON. This
+is the bundle directory. The output will need to be a ManifestResult JSON. This
 JSON will be parsed by the operator-sdk converted and output as a Result.
 
 For example, the existing validations could easily be wrapped with a `main.go`
@@ -155,17 +155,17 @@ the [`OperatorHubValidator`][validator-poc1] as a Go binary.
 
 As stated earlier, each validator should be some executable that accepts a
 single argument, the bundle root directory. Th validators should also output
-ManifestErrors JSON to stdout.
+ManifestResult JSON to stdout.
 
 Because the [existing validators](#default-validators-run-by-operator-sdk)
-currently return a [ManifestErrors][manifest-errors], it seems logical that we
+currently return a [ManifestResult][manifest-result], it seems logical that we
 use the same object as JSON for the output.
 
 The validator executable should exit non-zero ONLY if the entrypoint failed to
 run NOT if the bundle validation fails.
 
 For example, let's say the validator is given a path to the gatekeeper bundle.
-The validator should validate the given bundle and output the ManifestErrors JSON.
+The validator should validate the given bundle and output the ManifestResult JSON.
 Here is an example of a run:
 
 ```json
@@ -186,7 +186,7 @@ Here is an example of a run:
 
 The above JSON will be read by the `operator-sdk` during `bundle validate`
 command and output the results as it does today. The example below shows what
-`operator-sdk bundle validate` would printout if given the ManifestErrors from
+`operator-sdk bundle validate` would printout if given the ManifestResult from
 above.
 
 ```json
@@ -201,7 +201,7 @@ above.
 }
 ```
 
-Allowing the validators to output ManifestErrors should make it easier to
+Allowing the validators to output ManifestResult should make it easier to
 transition existing validators to the external format with minimal code.
 
 ##### Migrating existing validator to executable
@@ -211,14 +211,14 @@ Then import the validator code from operator-framework/api. The `main.go` would
 take in one (1) argument, the bundle directory.
 
 Since the [existing validators](#default-validators-run-by-operator-sdk) already
-output `ManifestErrors`, it's easiest if we simply print that out as JSON to
+output `ManifestResult`, it's easiest if we simply print that out as JSON to
 stdout.
 
-An example POC that takes an existing validator and outputs `ManifestErrors` can
+An example POC that takes an existing validator and outputs `ManifestResult` can
 be found at [validator-poc][validator-poc1]
 
 Another example of a migration can be find at [ocp-olm-catalog-validator][camila-poc].
-This particular example does NOT yet output `ManifestErrors` format.
+This particular example does NOT yet output `ManifestResult` format.
 
 TODO: do we need to add `json` tags to these structs?
 https://github.com/operator-framework/api/blob/master/pkg/validation/errors/error.go#L9-L16
@@ -422,7 +422,7 @@ enhancement:
 * The version of the validators can change however the validator author sees fit.
 * The API or contract between `operator-sdk` and validators will be
   * input to validator: bundle directory
-  * output from validator: `ManifestErrors` JSON
+  * output from validator: `ManifestResult` JSON
 
 ## Implementation History
 
@@ -489,6 +489,6 @@ started right away.
 https://github.com/operator-framework/api/tree/master/pkg/validation
 
 [phase-2]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-2.md
-[manifest-errors]: https://github.com/operator-framework/api/blob/master/pkg/validation/errors/error.go#L9-L16
+[manifest-result]: https://github.com/operator-framework/api/blob/master/pkg/validation/errors/error.go#L9-L16
 [validator-poc1]: https://github.com/jmrodri/validator-poc/tree/poc1-manifestresults
 [camila-poc]: https://github.com/camilamacedo86/ocp-olm-catalog-validator

--- a/enhancements/sdk-external-and-pluggable-validations.md
+++ b/enhancements/sdk-external-and-pluggable-validations.md
@@ -3,13 +3,12 @@ title: sdk-external-and-pluggable-validations
 authors:
   - "@jmrodri"
 reviewers:
-  - TBD
-  - "@camila"
-  - "@joe"
+  - "@camilamacedo86"
+  - "@joelanford"
+  - "@bparees"
 approvers:
-  - TBD
-  - "@camila"
-  - "@joe"
+  - "@camilamacedo86"
+  - "@joelanford"
 creation-date: 2021-10-01
 last-updated: 2021-10-01
 status: implementable
@@ -57,14 +56,18 @@ as 3 weeks away.
 
 List the specific goals of the proposal. How will we know that this has succeeded?
 
+* allow validations to be updated when the business needs them to be
+* do not require newer builds of the operator-sdk to get updates
+* allow validations to be hosted in their own repos
+* allow validations to be run external to operator-sdk
+
 ### Non-Goals
 
+TODO:
 What is out of scope for this proposal? Listing non-goals helps to focus discussion
 and make progress.
 
 ## Proposal
-
-This is where we get down to the nitty gritty of what the proposal actually is.
 
 ### User Stories [optional]
 
@@ -74,14 +77,20 @@ the system. The goal here is to make this feel real for users without getting
 bogged down.
 
 #### Story 1
+* as a CVP admin I would like to change the validation for XXX and have it
+  useable right now.
 
 #### Story 2
+* as a user
 
 ### Implementation Details/Notes/Constraints [optional]
 
 What are the caveats to the implementation? What are some important details that
 didn't come across above. Go in to as much detail as necessary here. This might
 be a good place to talk about core concepts and how they releate.
+
+
+
 
 ### Risks and Mitigations
 


### PR DESCRIPTION
Today, validations used by CVP are compiled into the operator-sdk. Any changes 
to the validation rules requires a release of operator-framework/api followed by
a release of operator-sdk. This proposal attempts to design a way where the 
validations can be hosted in their own repos as well as updated without
requiring new releases of the operator-sdk.
